### PR TITLE
13 sad path testing

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -19,8 +19,13 @@ module Api
 
       def update 
         subscription = Subscription.find(params[:id])
-        subscription.update(status: "deactivated")
-        render json: SubscriptionSerializer.new(subscription)
+        if subscription.status == "active"
+          subscription.update(status: "deactivated")
+          render json: SubscriptionSerializer.new(subscription)
+        else  
+          subscription.update(status: "active")
+          render json: SubscriptionSerializer.new(subscription)
+        end
       end
 
       private 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,4 +1,10 @@
 class Subscription < ApplicationRecord
   belongs_to :customer
   belongs_to :tea 
+  validates :title, presence: true 
+  validates :price, presence: true 
+  validates :status, presence: true 
+  validates :frequency, presence: true 
+  validates :customer_id, presence: true 
+  validates :tea_id, presence: true 
 end

--- a/spec/requests/api/v1/subscriptions/cancel_spec.rb
+++ b/spec/requests/api/v1/subscriptions/cancel_spec.rb
@@ -21,4 +21,25 @@ RSpec.describe "Cancel Subscriptions API" do
     
     expect(subscription_1.status).to eq("deactivated")
   end 
+
+  it "can activate a deactivated status" do 
+    customer_1 = Customer.create!(first_name: "Nick", last_name: "Tassinari", email: "nick@gmail.com", address: "504 nunya business way")
+    tea_1 = Tea.create!(title: "Sencha", description: "Japanese green tea", temperature: "100", brew_time: "3 minutes")
+    
+    subscription_1 = Subscription.create!( 
+        title: "Tea o the Month",
+        price: 19.99,
+        status: "deactivated",
+        frequency: "monthly",
+        customer_id: customer_1.id, 
+        tea_id: tea_1.id)
+    
+    patch "/api/v1/customers/#{customer_1.id}/subscriptions/#{subscription_1.id}"
+    
+    expect(response).to have_http_status(200)
+
+    subscription_1.reload
+    
+    expect(subscription_1.status).to eq("active")
+  end
 end 

--- a/spec/requests/api/v1/subscriptions/create_spec.rb
+++ b/spec/requests/api/v1/subscriptions/create_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Create Subscriptions API" do
     expect(response).to have_http_status(201)
 
     subscription = JSON.parse(response.body)
-    require 'pry'; binding.pry
+
     expect(subscription).to have_key("data")
     expect(subscription["data"]).to have_key("attributes")
     expect(subscription["data"]["attributes"]["title"]).to eq("Tea o the Month")
@@ -29,5 +29,24 @@ RSpec.describe "Create Subscriptions API" do
     expect(subscription["data"]["attributes"]["frequency"]).to eq("monthly")
     expect(subscription["data"]["attributes"]["customer_id"]).to eq(customer_1.id)
     expect(subscription["data"]["attributes"]["tea_id"]).to eq(tea_1.id)
+  end
+
+  it "cannot create an invalid subscription" do 
+    customer_1 = Customer.create!(first_name: "Nick", last_name: "Tassinari", email: "nick@gmail.com", address: "504 nunya business way")
+    tea_1 = Tea.create!(title: "Sencha", description: "Japanese green tea", temperature: "100", brew_time: "3 minutes")
+    
+    #missing price
+    subscription_params = { 
+      subscription: {
+        title: "Tea o the Month",
+        status: "active",
+        frequency: "monthly",
+        customer_id: customer_1.id, 
+        tea_id: tea_1.id
+      }
+    }
+    post "/api/v1/customers/#{customer_1.id}/subscriptions", params: subscription_params
+    
+    expect(response).to have_http_status(422)
   end
 end


### PR DESCRIPTION
This PR adds sad path testing for create and update actions on subscription.
If there is an invalid subscription passed into the create action we get an error.
For the update if the sub has already been cancelled we can now re-activate it!